### PR TITLE
Add $post_type functionality 

### DIFF
--- a/WPEloquent/Model/Post.php
+++ b/WPEloquent/Model/Post.php
@@ -10,10 +10,19 @@ class Post extends  \Illuminate\Database\Eloquent\Model {
 
     protected $table      = 'posts';
     protected $primaryKey = 'ID';
+    protected $post_type = null;
     public $timestamps    = false;
 
     const CREATED_AT = 'post_date';
 	const UPDATED_AT = 'post_modified';
+	
+	public function newQuery() {
+		$query = parent::newQuery();
+		if($this->post_type) {
+			return $this->scopeType($query, $this->post_type);
+		}
+		return $query;
+	}
 
     public function author () {
         return $this->hasOne(\WPEloquent\Model\User::class, 'ID', 'post_author');


### PR DESCRIPTION
This helps with simplifying `type` scope so users can do this:

```php
	namespace Theme\Models;

	use WPEloquent\Model\Post;
	
	class Product extends Post {
		
		protected $post_type = 'product';
		
	}
```

```php
// this will return a product automatically
var_dump(Product::first());
```